### PR TITLE
Make example Arduino IDE compatible - add button

### DIFF
--- a/examples/Home_Automation_screen_test/Home_Automation_screen_test.ino
+++ b/examples/Home_Automation_screen_test/Home_Automation_screen_test.ino
@@ -1,0 +1,24 @@
+
+#include <TFT_eSPI_ext.h>
+
+TFT_eSPI_ext tft = TFT_eSPI_ext();
+TFT_eSPI_Button Button1;
+
+#include "screens.h" // Must include after any button instances have been created
+
+void setup() {
+  Serial.begin(115200);
+  Serial.println(""); Serial.println("");
+  Serial.println("TFT_eSPI_ext library test!");
+
+  tft.init();
+  Button1.initButton(&tft,400, 30, 141, 43, 0xFFFF, 0x2A54, 0xFFFF, "SETUP", 2);
+
+  tft.setRotation(1);
+  tft.fillScreen(TFT_GREEN);
+
+  Screen2();
+}
+
+void loop(void) {
+}

--- a/examples/Home_Automation_screen_test/screens.h
+++ b/examples/Home_Automation_screen_test/screens.h
@@ -15,15 +15,13 @@
 #include <font_Arial.h> // Size: 8, 11, 15
 #include <font_ArialBold.h> // Size: 8, 11, 13, 15
 
-TFT_eSPI_Button Button1;
-
 // Hints:
 //	- add tft.setRotation(1) or tft.setRotation(3) for landscape mode
 //	- for texts, you may want to specify the background color:
 //		tft.setTextColor(ForeColor, BackColor);
 //	- note, displays handle rotations differently so you may have to swap fillScreenVGradient for fillScreenHGradient
 
-// PowerPoint slide rounded rectangles will be turned into Adafruit style buttons on the TFT
+// Rounded rectangles will be turned into Adafruit buttons
 // add code for touch screen processing
 
 void Screen1(void)

--- a/examples/WT32-SC01-test-ttf-gradients/src/main.cpp
+++ b/examples/WT32-SC01-test-ttf-gradients/src/main.cpp
@@ -1,23 +1,25 @@
 
-
-#include <TFT_eSPI.h>
 #include <TFT_eSPI_ext.h>
 
-#include "screens.h"
-
+// The following comment is more relevant to enhancing the library?
+// If these can be included in a sketch then a "how to" is needed.
 // More than 900 Fonts available here:
 // https://github.com/FrankBoesing/fonts/tree/master/ofl
 
-//TFT_eSPI tft = TFT_eSPI();
 TFT_eSPI_ext tft = TFT_eSPI_ext();
 
+#include "screens.h" // Must include after tft instance created
 
+/*
+Things are undefined here in the Arduino environment - maybe was in platformio.ini?
+TFT_eSPI will switch on backlight so delete this and leave user to add own code
 void setBacklight(char brightness) //0..100
 {
     const float fact = ((1 << BACKLIGHT_RESOLUTION) - 1) / 100.0f;
     if (brightness > 100) brightness = 100;
     ledcWrite(BACKLIGHT_CHANNEL, fact * brightness );
 }
+*/
 
 void setup() {
 
@@ -26,13 +28,18 @@ void setup() {
   Serial.println("TFT_eSPI_ext library test!");
 
   tft.init();
-  // tft.fillScreen(TFT_BLACK);
+  tft.fillScreen(TFT_BLACK);
   tft.setRotation(1);
 
+/*
+Things are undefined here in the Arduino environment
+TFT_eSPI will switch on backlight so delete this and leave user to add own code
 
   ledcSetup(BACKLIGHT_CHANNEL, BACKLIGHT_FREQ, BACKLIGHT_RESOLUTION);
   ledcAttachPin(TFT_BL, BACKLIGHT_CHANNEL);
   setBacklight(20);
+*/
+
   Screen2();
 }
 


### PR DESCRIPTION
If example is in folder named  zzyx then sketch must be called zzyx.ino

The example code is not directly compatible with the Arduino IDE. A compatible example is included based on the provided example. The provided example has been editted to show the changes needed to be Arduino IDE compatible.

The button handler has been added to use the TFT_eSPI builtin button class.